### PR TITLE
[Mellanox] Update two patches which rebased on top of 4.19.118

### DIFF
--- a/patch/0001-Mellanox-platform-Backport-patches-for-new-Mellanox-.patch
+++ b/patch/0001-Mellanox-platform-Backport-patches-for-new-Mellanox-.patch
@@ -1,8 +1,8 @@
-From 94c3405f5b95f3f699ad8167630b4fbf9a788dce Mon Sep 17 00:00:00 2001
+From e4149afc593ef4bc14d5980a9a72413fd0406750 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@mellanox.com>
-Date: Tue, 4 Feb 2020 23:30:59 +0200
-Subject: [PATCH 1/2] v4.19-6: Mellanox platform: Backport patches for new
- Mellanox systems
+Date: Mon, 29 Jun 2020 18:48:23 +0300
+Subject: [backport 01/12] Mellanox platform: Backport patches for new Mellanox
+ systems
 
 It contains backport patches from v4.20 - v5.5 and below bug fixes and
 optimizations.
@@ -27,23 +27,17 @@ Add thermal zone platform parameters definition with the field
 "no_hwmon" set to true. Use it in thermal_zone_device_register().
 It will indicate that the "thermal" to "hwmon" sysfs interface is not
 
-Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
-Signed-off-by: Stephen Sun <stephens@mellanox.com>
+Adding module for ethtool support.
 
-v4.19-6: Mellanox platform: Additional backport for new Mellanox systems
+Changing Mellanox i2c bus poling time frequency.
 
-It contains backport patches from v5.* kernels:
-- Adding module for ethtool support.
-- Changing Mellanox i2c bus poling time frequency.
-- Watchdog Mellanox driver.
+Adding watchdog Mellanox driver.
 
 Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
-Signed-off-by: Stephen Sun <stephens@mellanox.com>
 ---
  drivers/hwmon/mlxreg-fan.c                         |   90 +-
- drivers/hwmon/pmbus/tps53679.c                     |   10 +-
  drivers/i2c/busses/i2c-mlxcpld.c                   |    2 +-
- drivers/leds/leds-mlxreg.c                         |   23 +-
+ drivers/leds/leds-mlxreg.c                         |   21 +-
  drivers/net/ethernet/mellanox/mlxsw/Kconfig        |    9 +
  drivers/net/ethernet/mellanox/mlxsw/Makefile       |    3 +-
  drivers/net/ethernet/mellanox/mlxsw/core.c         |   82 +-
@@ -52,20 +46,19 @@ Signed-off-by: Stephen Sun <stephens@mellanox.com>
  drivers/net/ethernet/mellanox/mlxsw/core_env.h     |   17 +
  drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c   |  361 +++++-
  drivers/net/ethernet/mellanox/mlxsw/core_thermal.c |  696 +++++++++-
- drivers/net/ethernet/mellanox/mlxsw/i2c.c          |  212 +++-
  drivers/net/ethernet/mellanox/mlxsw/minimal.c      |  328 ++++-
  drivers/net/ethernet/mellanox/mlxsw/pci.c          |   49 +-
  drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c   |  454 +++++++
- drivers/net/ethernet/mellanox/mlxsw/reg.h          | 1243 +++++++++++++++++-
+ drivers/net/ethernet/mellanox/mlxsw/reg.h          | 1221 +++++++++++++++++-
  drivers/net/ethernet/mellanox/mlxsw/resources.h    |    6 +
  drivers/platform/mellanox/mlxreg-hotplug.c         |   42 +-
- drivers/platform/x86/mlx-platform.c                | 1332 +++++++++++++++++---
+ drivers/platform/x86/mlx-platform.c                | 1328 +++++++++++++++++---
  drivers/watchdog/Kconfig                           |   16 +
  drivers/watchdog/Makefile                          |    1 +
  drivers/watchdog/mlx_wdt.c                         |  289 +++++
  include/linux/platform_data/mlxreg.h               |   27 +-
  include/uapi/linux/ethtool.h                       |    3 +
- 25 files changed, 5247 insertions(+), 340 deletions(-)
+ 23 files changed, 5039 insertions(+), 298 deletions(-)
  create mode 100644 drivers/net/ethernet/mellanox/mlxsw/core_env.c
  create mode 100644 drivers/net/ethernet/mellanox/mlxsw/core_env.h
  create mode 100644 drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c
@@ -95,7 +88,7 @@ index d8fa4be..7028a4f 100644
  #define MLXREG_FAN_PWM_DUTY2STATE(duty)	(DIV_ROUND_CLOSEST((duty) *	\
  					 MLXREG_FAN_MAX_STATE,		\
  					 MLXREG_FAN_MAX_DUTY))
-@@ -360,15 +362,57 @@ static int mlxreg_fan_set_cur_state(struct thermal_cooling_device *cdev,
+@@ -360,15 +362,57 @@ static const struct thermal_cooling_device_ops mlxreg_fan_cooling_ops = {
  	.set_cur_state	= mlxreg_fan_set_cur_state,
  };
  
@@ -248,27 +241,6 @@ index d8fa4be..7028a4f 100644
  			return PTR_ERR(fan->cdev);
  		}
  	}
-diff --git a/drivers/hwmon/pmbus/tps53679.c b/drivers/hwmon/pmbus/tps53679.c
-index 85b515c..45eacc5 100644
---- a/drivers/hwmon/pmbus/tps53679.c
-+++ b/drivers/hwmon/pmbus/tps53679.c
-@@ -80,7 +80,15 @@ static int tps53679_identify(struct i2c_client *client,
- static int tps53679_probe(struct i2c_client *client,
- 			  const struct i2c_device_id *id)
- {
--	return pmbus_do_probe(client, id, &tps53679_info);
-+	struct pmbus_driver_info *info;
-+
-+	info = devm_kzalloc(&client->dev, sizeof(*info), GFP_KERNEL);
-+	if (!info)
-+		return -ENOMEM;
-+
-+	memcpy(info, &tps53679_info, sizeof(*info));
-+
-+	return pmbus_do_probe(client, id, info);
- }
- 
- static const struct i2c_device_id tps53679_id[] = {
 diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
 index 2fd717d..6da4b58 100644
 --- a/drivers/i2c/busses/i2c-mlxcpld.c
@@ -283,7 +255,7 @@ index 2fd717d..6da4b58 100644
  /* LPC I2C registers */
  #define MLXCPLD_LPCI2C_CPBLTY_REG	0x0
 diff --git a/drivers/leds/leds-mlxreg.c b/drivers/leds/leds-mlxreg.c
-index 1ee48cb..0c14a74 100644
+index 1ee48cb..781eb03 100644
 --- a/drivers/leds/leds-mlxreg.c
 +++ b/drivers/leds/leds-mlxreg.c
 @@ -22,6 +22,7 @@
@@ -328,15 +300,6 @@ index 1ee48cb..0c14a74 100644
  		led_cdev = &led_data->led_cdev;
  		led_data->data_parent = priv;
  		if (strstr(data->label, "red") ||
-@@ -213,7 +232,7 @@ static int mlxreg_led_config(struct mlxreg_led_priv_data *priv)
- 			data->label);
- 		led_cdev->name = led_data->led_cdev_name;
- 		led_cdev->brightness = brightness;
--		led_cdev->max_brightness = LED_ON;
-+		led_cdev->max_brightness = 1;
- 		led_cdev->brightness_set_blocking =
- 						mlxreg_led_brightness_set;
- 		led_cdev->brightness_get = mlxreg_led_brightness_get;
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/Kconfig b/drivers/net/ethernet/mellanox/mlxsw/Kconfig
 index 8a291eb..51e485b 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/Kconfig
@@ -398,7 +361,7 @@ index 2e6df58..c38c1c5 100644
  struct mlxsw_rx_listener_item {
  	struct list_head list;
  	struct mlxsw_rx_listener rxl;
-@@ -971,9 +978,9 @@ static int mlxsw_devlink_core_bus_device_reload(struct devlink *devlink,
+@@ -971,9 +978,9 @@ static const struct devlink_ops mlxsw_devlink_ops = {
  };
  
  int mlxsw_core_bus_device_register(const struct mlxsw_bus_info *mlxsw_bus_info,
@@ -528,7 +491,7 @@ diff --git a/drivers/net/ethernet/mellanox/mlxsw/core.h b/drivers/net/ethernet/m
 index c4e4971..3fb3a75 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/core.h
 +++ b/drivers/net/ethernet/mellanox/mlxsw/core.h
-@@ -28,6 +28,8 @@
+@@ -28,6 +28,8 @@ unsigned int mlxsw_core_max_ports(const struct mlxsw_core *mlxsw_core);
  
  void *mlxsw_core_driver_priv(struct mlxsw_core *mlxsw_core);
  
@@ -1489,7 +1452,7 @@ index 6d29dc4..b753729 100644
  		.min_state	= MLXSW_THERMAL_MAX_STATE,
  		.max_state	= MLXSW_THERMAL_MAX_STATE,
  	}
-@@ -63,13 +91,32 @@ struct mlxsw_thermal_trip {
+@@ -63,13 +91,32 @@ static const struct mlxsw_thermal_trip default_thermal_trips[] = {
  /* Make sure all trips are writable */
  #define MLXSW_THERMAL_TRIP_MASK	(BIT(MLXSW_THERMAL_NUM_TRIPS) - 1)
  
@@ -1662,7 +1625,7 @@ index 6d29dc4..b753729 100644
  static struct thermal_zone_device_ops mlxsw_thermal_ops = {
  	.bind = mlxsw_thermal_bind,
  	.unbind = mlxsw_thermal_unbind,
-@@ -243,6 +376,242 @@ static int mlxsw_thermal_set_trip_temp(struct thermal_zone_device *tzdev,
+@@ -243,6 +376,242 @@ static struct thermal_zone_device_ops mlxsw_thermal_ops = {
  	.get_trip_type	= mlxsw_thermal_get_trip_type,
  	.get_trip_temp	= mlxsw_thermal_get_trip_temp,
  	.set_trip_temp	= mlxsw_thermal_set_trip_temp,
@@ -1958,7 +1921,7 @@ index 6d29dc4..b753729 100644
  	mlxsw_reg_mfsc_pack(mfsc_pl, idx, mlxsw_state_to_duty(state));
  	err = mlxsw_reg_write(thermal->core, MLXSW_REG(mfsc), mfsc_pl);
  	if (err) {
-@@ -306,6 +714,218 @@ static int mlxsw_thermal_set_cur_state(struct thermal_cooling_device *cdev,
+@@ -306,6 +714,218 @@ static const struct thermal_cooling_device_ops mlxsw_cooling_ops = {
  	.set_cur_state	= mlxsw_thermal_set_cur_state,
  };
  
@@ -2258,392 +2221,6 @@ index 6d29dc4..b753729 100644
  	if (thermal->tzdev) {
  		thermal_zone_device_unregister(thermal->tzdev);
  		thermal->tzdev = NULL;
-diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
-index 798bd5a..e04d521 100644
---- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
-+++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
-@@ -14,14 +14,17 @@
- #include "cmd.h"
- #include "core.h"
- #include "i2c.h"
-+#include "resources.h"
- 
- #define MLXSW_I2C_CIR2_BASE		0x72000
- #define MLXSW_I2C_CIR_STATUS_OFF	0x18
- #define MLXSW_I2C_CIR2_OFF_STATUS	(MLXSW_I2C_CIR2_BASE + \
- 					 MLXSW_I2C_CIR_STATUS_OFF)
- #define MLXSW_I2C_OPMOD_SHIFT		12
-+#define MLXSW_I2C_EVENT_BIT_SHIFT	22
- #define MLXSW_I2C_GO_BIT_SHIFT		23
- #define MLXSW_I2C_CIR_CTRL_STATUS_SHIFT	24
-+#define MLXSW_I2C_EVENT_BIT		BIT(MLXSW_I2C_EVENT_BIT_SHIFT)
- #define MLXSW_I2C_GO_BIT		BIT(MLXSW_I2C_GO_BIT_SHIFT)
- #define MLXSW_I2C_GO_OPMODE		BIT(MLXSW_I2C_OPMOD_SHIFT)
- #define MLXSW_I2C_SET_IMM_CMD		(MLXSW_I2C_GO_OPMODE | \
-@@ -33,17 +36,20 @@
- #define MLXSW_I2C_TLV_HDR_SIZE		0x10
- #define MLXSW_I2C_ADDR_WIDTH		4
- #define MLXSW_I2C_PUSH_CMD_SIZE		(MLXSW_I2C_ADDR_WIDTH + 4)
-+#define MLXSW_I2C_SET_EVENT_CMD		(MLXSW_I2C_EVENT_BIT)
-+#define MLXSW_I2C_PUSH_EVENT_CMD	(MLXSW_I2C_GO_BIT | \
-+					 MLXSW_I2C_SET_EVENT_CMD)
- #define MLXSW_I2C_READ_SEMA_SIZE	4
- #define MLXSW_I2C_PREP_SIZE		(MLXSW_I2C_ADDR_WIDTH + 28)
- #define MLXSW_I2C_MBOX_SIZE		20
- #define MLXSW_I2C_MBOX_OUT_PARAM_OFF	12
--#define MLXSW_I2C_MAX_BUFF_SIZE		32
- #define MLXSW_I2C_MBOX_OFFSET_BITS	20
- #define MLXSW_I2C_MBOX_SIZE_BITS	12
- #define MLXSW_I2C_ADDR_BUF_SIZE		4
--#define MLXSW_I2C_BLK_MAX		32
-+#define MLXSW_I2C_BLK_DEF		32
- #define MLXSW_I2C_RETRY			5
- #define MLXSW_I2C_TIMEOUT_MSECS		5000
-+#define MLXSW_I2C_MAX_DATA_SIZE		256
- 
- /**
-  * struct mlxsw_i2c - device private data:
-@@ -55,6 +61,7 @@
-  * @dev: I2C device;
-  * @core: switch core pointer;
-  * @bus_info: bus info block;
-+ * @block_size: maximum block size allowed to pass to under layer;
-  */
- struct mlxsw_i2c {
- 	struct {
-@@ -67,6 +74,7 @@ struct mlxsw_i2c {
- 	struct device *dev;
- 	struct mlxsw_core *core;
- 	struct mlxsw_bus_info bus_info;
-+	u16 block_size;
- };
- 
- #define MLXSW_I2C_READ_MSG(_client, _addr_buf, _buf, _len) {	\
-@@ -167,7 +175,7 @@ static int mlxsw_i2c_wait_go_bit(struct i2c_client *client,
- 	return err > 0 ? 0 : err;
- }
- 
--/* Routine posts a command to ASIC though mail box. */
-+/* Routine posts a command to ASIC through mail box. */
- static int mlxsw_i2c_write_cmd(struct i2c_client *client,
- 			       struct mlxsw_i2c *mlxsw_i2c,
- 			       int immediate)
-@@ -213,6 +221,66 @@ static int mlxsw_i2c_write_cmd(struct i2c_client *client,
- 	return 0;
- }
- 
-+/* Routine posts initialization command to ASIC through mail box. */
-+static int
-+mlxsw_i2c_write_init_cmd(struct i2c_client *client,
-+			 struct mlxsw_i2c *mlxsw_i2c, u16 opcode, u32 in_mod)
-+{
-+	__be32 push_cmd_buf[MLXSW_I2C_PUSH_CMD_SIZE / 4] = {
-+		0, cpu_to_be32(MLXSW_I2C_PUSH_EVENT_CMD)
-+	};
-+	__be32 prep_cmd_buf[MLXSW_I2C_PREP_SIZE / 4] = {
-+		0, 0, 0, 0, 0, 0,
-+		cpu_to_be32(client->adapter->nr & 0xffff),
-+		cpu_to_be32(MLXSW_I2C_SET_EVENT_CMD)
-+	};
-+	struct i2c_msg push_cmd =
-+		MLXSW_I2C_WRITE_MSG(client, push_cmd_buf,
-+				    MLXSW_I2C_PUSH_CMD_SIZE);
-+	struct i2c_msg prep_cmd =
-+		MLXSW_I2C_WRITE_MSG(client, prep_cmd_buf, MLXSW_I2C_PREP_SIZE);
-+	u8 status;
-+	int err;
-+
-+	push_cmd_buf[1] = cpu_to_be32(MLXSW_I2C_PUSH_EVENT_CMD | opcode);
-+	prep_cmd_buf[3] = cpu_to_be32(in_mod);
-+	prep_cmd_buf[7] = cpu_to_be32(MLXSW_I2C_GO_BIT | opcode);
-+	mlxsw_i2c_set_slave_addr((u8 *)prep_cmd_buf,
-+				 MLXSW_I2C_CIR2_BASE);
-+	mlxsw_i2c_set_slave_addr((u8 *)push_cmd_buf,
-+				 MLXSW_I2C_CIR2_OFF_STATUS);
-+
-+	/* Prepare Command Interface Register for transaction */
-+	err = i2c_transfer(client->adapter, &prep_cmd, 1);
-+	if (err < 0)
-+		return err;
-+	else if (err != 1)
-+		return -EIO;
-+
-+	/* Write out Command Interface Register GO bit to push transaction */
-+	err = i2c_transfer(client->adapter, &push_cmd, 1);
-+	if (err < 0)
-+		return err;
-+	else if (err != 1)
-+		return -EIO;
-+
-+	/* Wait until go bit is cleared. */
-+	err = mlxsw_i2c_wait_go_bit(client, mlxsw_i2c, &status);
-+	if (err) {
-+		dev_err(&client->dev, "HW semaphore is not released");
-+		return err;
-+	}
-+
-+	/* Validate transaction completion status. */
-+	if (status) {
-+		dev_err(&client->dev, "Bad transaction completion status %x\n",
-+			status);
-+		return -EIO;
-+	}
-+
-+	return 0;
-+}
-+
- /* Routine obtains mail box offsets from ASIC register space. */
- static int mlxsw_i2c_get_mbox(struct i2c_client *client,
- 			      struct mlxsw_i2c *mlxsw_i2c)
-@@ -248,20 +316,26 @@ static int mlxsw_i2c_get_mbox(struct i2c_client *client,
- 	struct i2c_client *client = to_i2c_client(dev);
- 	struct mlxsw_i2c *mlxsw_i2c = i2c_get_clientdata(client);
- 	unsigned long timeout = msecs_to_jiffies(MLXSW_I2C_TIMEOUT_MSECS);
--	u8 tran_buf[MLXSW_I2C_MAX_BUFF_SIZE + MLXSW_I2C_ADDR_BUF_SIZE];
- 	int off = mlxsw_i2c->cmd.mb_off_in, chunk_size, i, j;
- 	unsigned long end;
-+	u8 *tran_buf;
- 	struct i2c_msg write_tran =
--		MLXSW_I2C_WRITE_MSG(client, tran_buf, MLXSW_I2C_PUSH_CMD_SIZE);
-+		MLXSW_I2C_WRITE_MSG(client, NULL, MLXSW_I2C_PUSH_CMD_SIZE);
- 	int err;
- 
-+	tran_buf = kmalloc(mlxsw_i2c->block_size + MLXSW_I2C_ADDR_BUF_SIZE,
-+			   GFP_KERNEL);
-+	if (!tran_buf)
-+		return -ENOMEM;
-+
-+	write_tran.buf = tran_buf;
- 	for (i = 0; i < num; i++) {
--		chunk_size = (in_mbox_size > MLXSW_I2C_BLK_MAX) ?
--			     MLXSW_I2C_BLK_MAX : in_mbox_size;
-+		chunk_size = (in_mbox_size > mlxsw_i2c->block_size) ?
-+			     mlxsw_i2c->block_size : in_mbox_size;
- 		write_tran.len = MLXSW_I2C_ADDR_WIDTH + chunk_size;
- 		mlxsw_i2c_set_slave_addr(tran_buf, off);
- 		memcpy(&tran_buf[MLXSW_I2C_ADDR_BUF_SIZE], in_mbox +
--		       MLXSW_I2C_BLK_MAX * i, chunk_size);
-+		       mlxsw_i2c->block_size * i, chunk_size);
- 
- 		j = 0;
- 		end = jiffies + timeout;
-@@ -275,9 +349,10 @@ static int mlxsw_i2c_get_mbox(struct i2c_client *client,
- 			 (j++ < MLXSW_I2C_RETRY));
- 
- 		if (err != 1) {
--			if (!err)
-+			if (!err) {
- 				err = -EIO;
--			return err;
-+				goto mlxsw_i2c_write_exit;
-+			}
- 		}
- 
- 		off += chunk_size;
-@@ -288,30 +363,33 @@ static int mlxsw_i2c_get_mbox(struct i2c_client *client,
- 	err = mlxsw_i2c_write_cmd(client, mlxsw_i2c, 0);
- 	if (err) {
- 		dev_err(&client->dev, "Could not start transaction");
--		return -EIO;
-+		err = -EIO;
-+		goto mlxsw_i2c_write_exit;
- 	}
- 
- 	/* Wait until go bit is cleared. */
- 	err = mlxsw_i2c_wait_go_bit(client, mlxsw_i2c, p_status);
- 	if (err) {
- 		dev_err(&client->dev, "HW semaphore is not released");
--		return err;
-+		goto mlxsw_i2c_write_exit;
- 	}
- 
- 	/* Validate transaction completion status. */
- 	if (*p_status) {
- 		dev_err(&client->dev, "Bad transaction completion status %x\n",
- 			*p_status);
--		return -EIO;
-+		err = -EIO;
- 	}
- 
--	return 0;
-+mlxsw_i2c_write_exit:
-+	kfree(tran_buf);
-+	return err;
- }
- 
- /* Routine executes I2C command. */
- static int
--mlxsw_i2c_cmd(struct device *dev, size_t in_mbox_size, u8 *in_mbox,
--	      size_t out_mbox_size, u8 *out_mbox, u8 *status)
-+mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
-+	      u8 *in_mbox, size_t out_mbox_size, u8 *out_mbox, u8 *status)
- {
- 	struct i2c_client *client = to_i2c_client(dev);
- 	struct mlxsw_i2c *mlxsw_i2c = i2c_get_clientdata(client);
-@@ -326,31 +404,47 @@ static int mlxsw_i2c_get_mbox(struct i2c_client *client,
- 
- 	WARN_ON(in_mbox_size % sizeof(u32) || out_mbox_size % sizeof(u32));
- 
--	reg_size = mlxsw_i2c_get_reg_size(in_mbox);
--	num = reg_size / MLXSW_I2C_BLK_MAX;
--	if (reg_size % MLXSW_I2C_BLK_MAX)
--		num++;
-+	if (in_mbox) {
-+		reg_size = mlxsw_i2c_get_reg_size(in_mbox);
-+		num = reg_size / mlxsw_i2c->block_size;
-+		if (reg_size % mlxsw_i2c->block_size)
-+			num++;
- 
--	if (mutex_lock_interruptible(&mlxsw_i2c->cmd.lock) < 0) {
--		dev_err(&client->dev, "Could not acquire lock");
--		return -EINVAL;
--	}
-+		if (mutex_lock_interruptible(&mlxsw_i2c->cmd.lock) < 0) {
-+			dev_err(&client->dev, "Could not acquire lock");
-+			return -EINVAL;
-+		}
- 
--	err = mlxsw_i2c_write(dev, reg_size, in_mbox, num, status);
--	if (err)
--		goto cmd_fail;
-+		err = mlxsw_i2c_write(dev, reg_size, in_mbox, num, status);
-+		if (err)
-+			goto cmd_fail;
-+
-+		/* No out mailbox is case of write transaction. */
-+		if (!out_mbox) {
-+			mutex_unlock(&mlxsw_i2c->cmd.lock);
-+			return 0;
-+		}
-+	} else {
-+		/* No input mailbox is case of initialization query command. */
-+		reg_size = MLXSW_I2C_MAX_DATA_SIZE;
-+		num = reg_size / mlxsw_i2c->block_size;
-+
-+		if (mutex_lock_interruptible(&mlxsw_i2c->cmd.lock) < 0) {
-+			dev_err(&client->dev, "Could not acquire lock");
-+			return -EINVAL;
-+		}
- 
--	/* No out mailbox is case of write transaction. */
--	if (!out_mbox) {
--		mutex_unlock(&mlxsw_i2c->cmd.lock);
--		return 0;
-+		err = mlxsw_i2c_write_init_cmd(client, mlxsw_i2c, opcode,
-+					       in_mod);
-+		if (err)
-+			goto cmd_fail;
- 	}
- 
- 	/* Send read transaction to get output mailbox content. */
- 	read_tran[1].buf = out_mbox;
- 	for (i = 0; i < num; i++) {
--		chunk_size = (reg_size > MLXSW_I2C_BLK_MAX) ?
--			     MLXSW_I2C_BLK_MAX : reg_size;
-+		chunk_size = (reg_size > mlxsw_i2c->block_size) ?
-+			     mlxsw_i2c->block_size : reg_size;
- 		read_tran[1].len = chunk_size;
- 		mlxsw_i2c_set_slave_addr(tran_buf, off);
- 
-@@ -395,8 +489,8 @@ static int mlxsw_i2c_cmd_exec(void *bus_priv, u16 opcode, u8 opcode_mod,
- {
- 	struct mlxsw_i2c *mlxsw_i2c = bus_priv;
- 
--	return mlxsw_i2c_cmd(mlxsw_i2c->dev, in_mbox_size, in_mbox,
--			     out_mbox_size, out_mbox, status);
-+	return mlxsw_i2c_cmd(mlxsw_i2c->dev, opcode, in_mod, in_mbox_size,
-+			     in_mbox, out_mbox_size, out_mbox, status);
- }
- 
- static bool mlxsw_i2c_skb_transmit_busy(void *bus_priv,
-@@ -414,13 +508,34 @@ static int mlxsw_i2c_skb_transmit(void *bus_priv, struct sk_buff *skb,
- static int
- mlxsw_i2c_init(void *bus_priv, struct mlxsw_core *mlxsw_core,
- 	       const struct mlxsw_config_profile *profile,
--	       struct mlxsw_res *resources)
-+	       struct mlxsw_res *res)
- {
- 	struct mlxsw_i2c *mlxsw_i2c = bus_priv;
-+	char *mbox;
-+	int err;
- 
- 	mlxsw_i2c->core = mlxsw_core;
- 
--	return 0;
-+	mbox = mlxsw_cmd_mbox_alloc();
-+	if (!mbox)
-+		return -ENOMEM;
-+
-+	err = mlxsw_cmd_query_fw(mlxsw_core, mbox);
-+	if (err)
-+		goto mbox_put;
-+
-+	mlxsw_i2c->bus_info.fw_rev.major =
-+		mlxsw_cmd_mbox_query_fw_fw_rev_major_get(mbox);
-+	mlxsw_i2c->bus_info.fw_rev.minor =
-+		mlxsw_cmd_mbox_query_fw_fw_rev_minor_get(mbox);
-+	mlxsw_i2c->bus_info.fw_rev.subminor =
-+		mlxsw_cmd_mbox_query_fw_fw_rev_subminor_get(mbox);
-+
-+	err = mlxsw_core_resources_query(mlxsw_core, mbox, res);
-+
-+mbox_put:
-+	mlxsw_cmd_mbox_free(mbox);
-+	return err;
- }
- 
- static void mlxsw_i2c_fini(void *bus_priv)
-@@ -442,6 +557,7 @@ static void mlxsw_i2c_fini(void *bus_priv)
- static int mlxsw_i2c_probe(struct i2c_client *client,
- 			   const struct i2c_device_id *id)
- {
-+	const struct i2c_adapter_quirks *quirks = client->adapter->quirks;
- 	struct mlxsw_i2c *mlxsw_i2c;
- 	u8 status;
- 	int err;
-@@ -450,6 +566,22 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
- 	if (!mlxsw_i2c)
- 		return -ENOMEM;
- 
-+	if (quirks) {
-+		if ((quirks->max_read_len &&
-+		     quirks->max_read_len < MLXSW_I2C_BLK_DEF) ||
-+		    (quirks->max_write_len &&
-+		     quirks->max_write_len < MLXSW_I2C_BLK_DEF)) {
-+			dev_err(&client->dev, "Insufficient transaction buffer length\n");
-+			return -EOPNOTSUPP;
-+		}
-+
-+		mlxsw_i2c->block_size = max_t(u16, MLXSW_I2C_BLK_DEF,
-+					      min_t(u16, quirks->max_read_len,
-+						    quirks->max_write_len));
-+	} else {
-+		mlxsw_i2c->block_size = MLXSW_I2C_BLK_DEF;
-+	}
-+
- 	i2c_set_clientdata(client, mlxsw_i2c);
- 	mutex_init(&mlxsw_i2c->cmd.lock);
- 
-@@ -503,6 +635,7 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
- 	mlxsw_i2c->bus_info.device_kind = id->name;
- 	mlxsw_i2c->bus_info.device_name = client->name;
- 	mlxsw_i2c->bus_info.dev = &client->dev;
-+	mlxsw_i2c->bus_info.low_frequency = true;
- 	mlxsw_i2c->dev = &client->dev;
- 
- 	err = mlxsw_core_bus_device_register(&mlxsw_i2c->bus_info,
-@@ -513,6 +646,11 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
- 		return err;
- 	}
- 
-+	dev_info(&client->dev, "Firmware revision: %d.%d.%d\n",
-+		 mlxsw_i2c->bus_info.fw_rev.major,
-+		 mlxsw_i2c->bus_info.fw_rev.minor,
-+		 mlxsw_i2c->bus_info.fw_rev.subminor);
-+
- 	return 0;
- 
- errout:
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
 index 5a6c445..504db12 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
@@ -3027,7 +2604,7 @@ diff --git a/drivers/net/ethernet/mellanox/mlxsw/pci.c b/drivers/net/ethernet/me
 index a903e97..b40455f 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/pci.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/pci.c
-@@ -1039,42 +1039,6 @@ static void mlxsw_pci_aqs_fini(struct mlxsw_pci *mlxsw_pci)
+@@ -1039,42 +1039,6 @@ mlxsw_pci_config_profile_swid_config(struct mlxsw_pci *mlxsw_pci,
  	mlxsw_cmd_mbox_config_profile_swid_config_mask_set(mbox, index, mask);
  }
  
@@ -3568,7 +3145,7 @@ index 0000000..49563a7
 +MODULE_AUTHOR("Vadim Pasternak <vadimp@mellanox.com>");
 +MODULE_DESCRIPTION("Mellanox switch QSFP sysfs driver");
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/reg.h b/drivers/net/ethernet/mellanox/mlxsw/reg.h
-index aee58b3..7ca9814 100644
+index c989587..7ca9814 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/reg.h
 +++ b/drivers/net/ethernet/mellanox/mlxsw/reg.h
 @@ -295,6 +295,7 @@ enum mlxsw_reg_sfd_rec_type {
@@ -3579,7 +3156,7 @@ index aee58b3..7ca9814 100644
  };
  
  /* reg_sfd_rec_type
-@@ -525,6 +526,61 @@ static inline void mlxsw_reg_sfd_uc_lag_unpack(char *payload, int rec_index,
+@@ -525,6 +526,61 @@ mlxsw_reg_sfd_mc_pack(char *payload, int rec_index,
  	mlxsw_reg_sfd_mc_mid_set(payload, rec_index, mid);
  }
  
@@ -3739,7 +3316,7 @@ index aee58b3..7ca9814 100644
   * Access: RW
   */
  MLXSW_ITEM32(reg, sfdf, flush_type, 0x04, 28, 4);
-@@ -1315,12 +1441,19 @@ enum mlxsw_reg_slcr_type {
+@@ -1315,12 +1441,19 @@ MLXSW_ITEM32(reg, slcr, type, 0x00, 0, 4);
   */
  MLXSW_ITEM32(reg, slcr, lag_hash, 0x04, 0, 20);
  
@@ -3760,7 +3337,7 @@ index aee58b3..7ca9814 100644
  }
  
  /* SLCOR - Switch LAG Collector Register
-@@ -2066,6 +2199,14 @@ static inline void mlxsw_reg_pacl_pack(char *payload, u16 acl_id,
+@@ -2066,6 +2199,14 @@ MLXSW_ITEM32(reg, pagt, size, 0x00, 0, 8);
   */
  MLXSW_ITEM32(reg, pagt, acl_group_id, 0x08, 0, 16);
  
@@ -3834,7 +3411,7 @@ index aee58b3..7ca9814 100644
  /* PTCE-V2 - Policy-Engine TCAM Entry Register Version 2
   * -----------------------------------------------------
   * This register is used for accessing rules within a TCAM region.
-@@ -2573,7 +2752,7 @@ static inline void mlxsw_reg_perpt_erp_vector_pack(char *payload,
+@@ -2573,7 +2752,7 @@ mlxsw_reg_perpt_pack(char *payload, u8 erpt_bank, u8 erpt_index,
  	mlxsw_reg_perpt_erpt_bank_set(payload, erpt_bank);
  	mlxsw_reg_perpt_erpt_index_set(payload, erpt_index);
  	mlxsw_reg_perpt_key_size_set(payload, key_size);
@@ -3947,50 +3524,7 @@ index aee58b3..7ca9814 100644
  /* IEDR - Infrastructure Entry Delete Register
   * ----------------------------------------------------
   * This register is used for deleting entries from the entry tables.
-@@ -3215,7 +3464,7 @@ static inline void mlxsw_reg_qtct_pack(char *payload, u8 local_port,
-  * Configures the ETS elements.
-  */
- #define MLXSW_REG_QEEC_ID 0x400D
--#define MLXSW_REG_QEEC_LEN 0x1C
-+#define MLXSW_REG_QEEC_LEN 0x20
- 
- MLXSW_REG_DEFINE(qeec, MLXSW_REG_QEEC_ID, MLXSW_REG_QEEC_LEN);
- 
-@@ -3257,6 +3506,15 @@ enum mlxsw_reg_qeec_hr {
-  */
- MLXSW_ITEM32(reg, qeec, next_element_index, 0x08, 0, 8);
- 
-+/* reg_qeec_mise
-+ * Min shaper configuration enable. Enables configuration of the min
-+ * shaper on this ETS element
-+ * 0 - Disable
-+ * 1 - Enable
-+ * Access: RW
-+ */
-+MLXSW_ITEM32(reg, qeec, mise, 0x0C, 31, 1);
-+
- enum {
- 	MLXSW_REG_QEEC_BYTES_MODE,
- 	MLXSW_REG_QEEC_PACKETS_MODE,
-@@ -3273,6 +3531,17 @@ enum {
-  */
- MLXSW_ITEM32(reg, qeec, pb, 0x0C, 28, 1);
- 
-+/* The smallest permitted min shaper rate. */
-+#define MLXSW_REG_QEEC_MIS_MIN	200000		/* Kbps */
-+
-+/* reg_qeec_min_shaper_rate
-+ * Min shaper information rate.
-+ * For CPU port, can only be configured for port hierarchy.
-+ * When in bytes mode, value is specified in units of 1000bps.
-+ * Access: RW
-+ */
-+MLXSW_ITEM32(reg, qeec, min_shaper_rate, 0x0C, 0, 28);
-+
- /* reg_qeec_mase
-  * Max shaper configuration enable. Enables configuration of the max
-  * shaper on this ETS element.
-@@ -4142,8 +4411,11 @@ static inline void mlxsw_reg_pfcc_pack(char *payload, u8 local_port)
+@@ -4162,8 +4411,11 @@ MLXSW_ITEM32(reg, ppcnt, pnat, 0x00, 14, 2);
  
  enum mlxsw_reg_ppcnt_grp {
  	MLXSW_REG_PPCNT_IEEE_8023_CNT = 0x0,
@@ -4002,7 +3536,7 @@ index aee58b3..7ca9814 100644
  	MLXSW_REG_PPCNT_PRIO_CNT = 0x10,
  	MLXSW_REG_PPCNT_TC_CNT = 0x11,
  	MLXSW_REG_PPCNT_TC_CONG_TC = 0x13,
-@@ -4158,6 +4430,7 @@ enum mlxsw_reg_ppcnt_grp {
+@@ -4178,6 +4430,7 @@ enum mlxsw_reg_ppcnt_grp {
   * 0x2: RFC 2819 Counters
   * 0x3: RFC 3635 Counters
   * 0x5: Ethernet Extended Counters
@@ -4010,7 +3544,7 @@ index aee58b3..7ca9814 100644
   * 0x8: Link Level Retransmission Counters
   * 0x10: Per Priority Counters
   * 0x11: Per Traffic Class Counters
-@@ -4301,8 +4574,46 @@ enum mlxsw_reg_ppcnt_grp {
+@@ -4321,8 +4574,46 @@ MLXSW_ITEM64(reg, ppcnt, a_pause_mac_ctrl_frames_received,
  MLXSW_ITEM64(reg, ppcnt, a_pause_mac_ctrl_frames_transmitted,
  	     MLXSW_REG_PPCNT_COUNTERS_OFFSET + 0x90, 0, 64);
  
@@ -4057,7 +3591,7 @@ index aee58b3..7ca9814 100644
  /* reg_ppcnt_ether_stats_pkts64octets
   * Access: RO
   */
-@@ -4363,6 +4674,32 @@ enum mlxsw_reg_ppcnt_grp {
+@@ -4383,6 +4674,32 @@ MLXSW_ITEM64(reg, ppcnt, ether_stats_pkts4096to8191octets,
  MLXSW_ITEM64(reg, ppcnt, ether_stats_pkts8192to10239octets,
  	     MLXSW_REG_PPCNT_COUNTERS_OFFSET + 0xA0, 0, 64);
  
@@ -4090,7 +3624,7 @@ index aee58b3..7ca9814 100644
  /* Ethernet Extended Counter Group Counters */
  
  /* reg_ppcnt_ecn_marked
-@@ -4371,6 +4708,80 @@ enum mlxsw_reg_ppcnt_grp {
+@@ -4391,6 +4708,80 @@ MLXSW_ITEM64(reg, ppcnt, ether_stats_pkts8192to10239octets,
  MLXSW_ITEM64(reg, ppcnt, ecn_marked,
  	     MLXSW_REG_PPCNT_COUNTERS_OFFSET + 0x08, 0, 64);
  
@@ -4171,7 +3705,7 @@ index aee58b3..7ca9814 100644
  /* Ethernet Per Priority Group Counters */
  
  /* reg_ppcnt_rx_octets
-@@ -4773,6 +5184,7 @@ enum mlxsw_reg_htgt_trap_group {
+@@ -4793,6 +5184,7 @@ enum mlxsw_reg_htgt_trap_group {
  	MLXSW_REG_HTGT_TRAP_GROUP_SP_EVENT,
  	MLXSW_REG_HTGT_TRAP_GROUP_SP_IPV6_MLD,
  	MLXSW_REG_HTGT_TRAP_GROUP_SP_IPV6_ND,
@@ -4179,7 +3713,7 @@ index aee58b3..7ca9814 100644
  };
  
  /* reg_htgt_trap_group
-@@ -5263,6 +5675,8 @@ enum mlxsw_reg_ritr_loopback_protocol {
+@@ -5283,6 +5675,8 @@ enum mlxsw_reg_ritr_loopback_protocol {
  	MLXSW_REG_RITR_LOOPBACK_PROTOCOL_IPIP_IPV4,
  	/* IPinIP IPv6 underlay Unicast */
  	MLXSW_REG_RITR_LOOPBACK_PROTOCOL_IPIP_IPV6,
@@ -4188,7 +3722,7 @@ index aee58b3..7ca9814 100644
  };
  
  /* reg_ritr_loopback_protocol
-@@ -5303,6 +5717,13 @@ enum mlxsw_reg_ritr_loopback_ipip_options {
+@@ -5323,6 +5717,13 @@ MLXSW_ITEM32(reg, ritr, loopback_ipip_options, 0x10, 20, 4);
   */
  MLXSW_ITEM32(reg, ritr, loopback_ipip_uvr, 0x10, 0, 16);
  
@@ -4202,7 +3736,7 @@ index aee58b3..7ca9814 100644
  /* reg_ritr_loopback_ipip_usip*
   * Encapsulation Underlay source IP.
   * Access: RW
-@@ -5418,11 +5839,12 @@ static inline void mlxsw_reg_ritr_mac_pack(char *payload, const char *mac)
+@@ -5438,11 +5839,12 @@ static inline void
  mlxsw_reg_ritr_loopback_ipip_common_pack(char *payload,
  			    enum mlxsw_reg_ritr_loopback_ipip_type ipip_type,
  			    enum mlxsw_reg_ritr_loopback_ipip_options options,
@@ -4216,7 +3750,7 @@ index aee58b3..7ca9814 100644
  	mlxsw_reg_ritr_loopback_ipip_gre_key_set(payload, gre_key);
  }
  
-@@ -5430,12 +5852,12 @@ static inline void mlxsw_reg_ritr_mac_pack(char *payload, const char *mac)
+@@ -5450,12 +5852,12 @@ static inline void
  mlxsw_reg_ritr_loopback_ipip4_pack(char *payload,
  			    enum mlxsw_reg_ritr_loopback_ipip_type ipip_type,
  			    enum mlxsw_reg_ritr_loopback_ipip_options options,
@@ -4231,7 +3765,7 @@ index aee58b3..7ca9814 100644
  	mlxsw_reg_ritr_loopback_ipip_usip4_set(payload, usip);
  }
  
-@@ -6797,6 +7219,13 @@ enum mlxsw_reg_rtdp_type {
+@@ -6817,6 +7219,13 @@ MLXSW_ITEM32(reg, rtdp, type, 0x00, 28, 4);
   */
  MLXSW_ITEM32(reg, rtdp, tunnel_index, 0x00, 0, 24);
  
@@ -4245,7 +3779,7 @@ index aee58b3..7ca9814 100644
  /* IPinIP */
  
  /* reg_rtdp_ipip_irif
-@@ -7446,6 +7875,35 @@ static inline void mlxsw_reg_mfsl_unpack(char *payload, u8 tacho,
+@@ -7466,6 +7875,35 @@ static inline void mlxsw_reg_mfsl_unpack(char *payload, u8 tacho,
  		*p_tach_max = mlxsw_reg_mfsl_tach_max_get(payload);
  }
  
@@ -4281,7 +3815,7 @@ index aee58b3..7ca9814 100644
  /* MTCAP - Management Temperature Capabilities
   * -------------------------------------------
   * This register exposes the capabilities of the device and
-@@ -7474,16 +7932,21 @@ static inline void mlxsw_reg_mfsl_unpack(char *payload, u8 tacho,
+@@ -7494,16 +7932,21 @@ MLXSW_ITEM32(reg, mtcap, sensor_count, 0x00, 0, 7);
  
  MLXSW_REG_DEFINE(mtmp, MLXSW_REG_MTMP_ID, MLXSW_REG_MTMP_LEN);
  
@@ -4305,7 +3839,7 @@ index aee58b3..7ca9814 100644
  
  /* reg_mtmp_temperature
   * Temperature reading from the sensor. Reading is in 0.125 Celsius
-@@ -7542,7 +8005,7 @@ static inline void mlxsw_reg_mfsl_unpack(char *payload, u8 tacho,
+@@ -7562,7 +8005,7 @@ MLXSW_ITEM32(reg, mtmp, temperature_threshold_lo, 0x10, 0, 16);
   */
  MLXSW_ITEM_BUF(reg, mtmp, sensor_name, 0x18, MLXSW_REG_MTMP_SENSOR_NAME_SIZE);
  
@@ -4314,7 +3848,7 @@ index aee58b3..7ca9814 100644
  				       bool max_temp_enable,
  				       bool max_temp_reset)
  {
-@@ -7554,11 +8017,10 @@ static inline void mlxsw_reg_mtmp_pack(char *payload, u8 sensor_index,
+@@ -7574,11 +8017,10 @@ static inline void mlxsw_reg_mtmp_pack(char *payload, u8 sensor_index,
  						    MLXSW_REG_MTMP_THRESH_HI);
  }
  
@@ -4329,7 +3863,7 @@ index aee58b3..7ca9814 100644
  
  	if (p_temp) {
  		temp = mlxsw_reg_mtmp_temperature_get(payload);
-@@ -7572,6 +8034,80 @@ static inline void mlxsw_reg_mtmp_unpack(char *payload, unsigned int *p_temp,
+@@ -7592,6 +8034,80 @@ static inline void mlxsw_reg_mtmp_unpack(char *payload, unsigned int *p_temp,
  		mlxsw_reg_mtmp_sensor_name_memcpy_from(payload, sensor_name);
  }
  
@@ -4410,7 +3944,7 @@ index aee58b3..7ca9814 100644
  /* MCIA - Management Cable Info Access
   * -----------------------------------
   * MCIA register is used to access the SFP+ and QSFP connector's EPROM.
-@@ -7626,13 +8162,48 @@ static inline void mlxsw_reg_mtmp_unpack(char *payload, unsigned int *p_temp,
+@@ -7646,13 +8162,48 @@ MLXSW_ITEM32(reg, mcia, device_address, 0x04, 0, 16);
   */
  MLXSW_ITEM32(reg, mcia, size, 0x08, 0, 16);
  
@@ -4461,7 +3995,7 @@ index aee58b3..7ca9814 100644
  
  static inline void mlxsw_reg_mcia_pack(char *payload, u8 module, u8 lock,
  				       u8 page_number, u16 device_addr,
-@@ -7968,6 +8539,43 @@ static inline void mlxsw_reg_mlcr_pack(char *payload, u8 local_port,
+@@ -7988,6 +8539,43 @@ static inline void mlxsw_reg_mlcr_pack(char *payload, u8 local_port,
  					   MLXSW_REG_MLCR_DURATION_MAX : 0);
  }
  
@@ -4505,7 +4039,7 @@ index aee58b3..7ca9814 100644
  /* MCQI - Management Component Query Information
   * ---------------------------------------------
   * This register allows querying information about firmware components.
-@@ -8279,6 +8887,567 @@ static inline void mlxsw_reg_mgpc_pack(char *payload, u32 counter_index,
+@@ -8299,6 +8887,567 @@ static inline void mlxsw_reg_mgpc_pack(char *payload, u32 counter_index,
  	mlxsw_reg_mgpc_opcode_set(payload, opcode);
  }
  
@@ -5073,7 +4607,7 @@ index aee58b3..7ca9814 100644
  /* TIGCR - Tunneling IPinIP General Configuration Register
   * -------------------------------------------------------
   * The TIGCR register is used for setting up the IPinIP Tunnel configuration.
-@@ -8336,8 +9505,15 @@ enum mlxsw_reg_sbxx_dir {
+@@ -8356,8 +9505,15 @@ MLXSW_ITEM32(reg, sbpr, dir, 0x00, 24, 2);
   */
  MLXSW_ITEM32(reg, sbpr, pool, 0x00, 0, 4);
  
@@ -5089,7 +4623,7 @@ index aee58b3..7ca9814 100644
   * Access: RW
   */
  MLXSW_ITEM32(reg, sbpr, size, 0x04, 0, 24);
-@@ -8355,13 +9531,15 @@ enum mlxsw_reg_sbpr_mode {
+@@ -8375,13 +9531,15 @@ MLXSW_ITEM32(reg, sbpr, mode, 0x08, 0, 4);
  
  static inline void mlxsw_reg_sbpr_pack(char *payload, u8 pool,
  				       enum mlxsw_reg_sbxx_dir dir,
@@ -5106,7 +4640,7 @@ index aee58b3..7ca9814 100644
  }
  
  /* SBCM - Shared Buffer Class Management Register
-@@ -8409,6 +9587,12 @@ static inline void mlxsw_reg_sbpr_pack(char *payload, u8 pool,
+@@ -8429,6 +9587,12 @@ MLXSW_ITEM32(reg, sbcm, min_buff, 0x18, 0, 24);
  #define MLXSW_REG_SBXX_DYN_MAX_BUFF_MIN 1
  #define MLXSW_REG_SBXX_DYN_MAX_BUFF_MAX 14
  
@@ -5119,7 +4653,7 @@ index aee58b3..7ca9814 100644
  /* reg_sbcm_max_buff
   * When the pool associated to the port-pg/tclass is configured to
   * static, Maximum buffer size for the limiter configured in cells.
-@@ -8418,6 +9602,7 @@ static inline void mlxsw_reg_sbpr_pack(char *payload, u8 pool,
+@@ -8438,6 +9602,7 @@ MLXSW_ITEM32(reg, sbcm, min_buff, 0x18, 0, 24);
   * 0: 0
   * i: (1/128)*2^(i-1), for i=1..14
   * 0xFF: Infinity
@@ -5127,7 +4661,7 @@ index aee58b3..7ca9814 100644
   * Access: RW
   */
  MLXSW_ITEM32(reg, sbcm, max_buff, 0x1C, 0, 24);
-@@ -8430,7 +9615,8 @@ static inline void mlxsw_reg_sbpr_pack(char *payload, u8 pool,
+@@ -8450,7 +9615,8 @@ MLXSW_ITEM32(reg, sbcm, pool, 0x24, 0, 4);
  
  static inline void mlxsw_reg_sbcm_pack(char *payload, u8 local_port, u8 pg_buff,
  				       enum mlxsw_reg_sbxx_dir dir,
@@ -5137,7 +4671,7 @@ index aee58b3..7ca9814 100644
  {
  	MLXSW_REG_ZERO(sbcm, payload);
  	mlxsw_reg_sbcm_local_port_set(payload, local_port);
-@@ -8438,6 +9624,7 @@ static inline void mlxsw_reg_sbcm_pack(char *payload, u8 local_port, u8 pg_buff,
+@@ -8458,6 +9624,7 @@ static inline void mlxsw_reg_sbcm_pack(char *payload, u8 local_port, u8 pg_buff,
  	mlxsw_reg_sbcm_dir_set(payload, dir);
  	mlxsw_reg_sbcm_min_buff_set(payload, min_buff);
  	mlxsw_reg_sbcm_max_buff_set(payload, max_buff);
@@ -5145,7 +4679,7 @@ index aee58b3..7ca9814 100644
  	mlxsw_reg_sbcm_pool_set(payload, pool);
  }
  
-@@ -8748,8 +9935,10 @@ static inline void mlxsw_reg_sbib_pack(char *payload, u8 local_port,
+@@ -8768,8 +9935,10 @@ static const struct mlxsw_reg_info *mlxsw_reg_infos[] = {
  	MLXSW_REG(ppbs),
  	MLXSW_REG(prcr),
  	MLXSW_REG(pefa),
@@ -5156,7 +4690,7 @@ index aee58b3..7ca9814 100644
  	MLXSW_REG(perar),
  	MLXSW_REG(ptce3),
  	MLXSW_REG(percr),
-@@ -8798,18 +9987,30 @@ static inline void mlxsw_reg_sbib_pack(char *payload, u8 local_port,
+@@ -8818,18 +9987,30 @@ static const struct mlxsw_reg_info *mlxsw_reg_infos[] = {
  	MLXSW_REG(mfsc),
  	MLXSW_REG(mfsm),
  	MLXSW_REG(mfsl),
@@ -5206,7 +4740,7 @@ index 79a31de..b8b3a01 100644
  
  	/* Internal resources.
  	 * Determined by the SW, not queried from the HW.
-@@ -91,11 +94,14 @@ enum mlxsw_res_id {
+@@ -91,11 +94,14 @@ static u16 mlxsw_res_ids[] = {
  	[MLXSW_RES_ID_ACL_ERPT_ENTRIES_4KB] = 0x2951,
  	[MLXSW_RES_ID_ACL_ERPT_ENTRIES_8KB] = 0x2952,
  	[MLXSW_RES_ID_ACL_ERPT_ENTRIES_12KB] = 0x2953,
@@ -5294,7 +4828,7 @@ index d52c821..77be37a 100644
  
  	priv->regmap = pdata->regmap;
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 742a0c2..c27548f 100644
+index 69e28c1..c27548f 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -1,34 +1,9 @@
@@ -5501,7 +5035,7 @@ index 742a0c2..c27548f 100644
  };
  
  /* Regions for LPC I2C controller and LPC base register space */
-@@ -173,6 +213,30 @@ struct mlxplat_priv {
+@@ -173,6 +213,30 @@ static const struct resource mlxplat_lpc_resources[] = {
  			       IORESOURCE_IO),
  };
  
@@ -5532,7 +5066,7 @@ index 742a0c2..c27548f 100644
  /* Platform default channels */
  static const int mlxplat_default_channels[][MLXPLAT_CPLD_GRP_CHNL_NUM] = {
  	{
-@@ -191,7 +255,33 @@ struct mlxplat_priv {
+@@ -191,7 +255,33 @@ static const int mlxplat_default_channels[][MLXPLAT_CPLD_GRP_CHNL_NUM] = {
  static const int mlxplat_msn21xx_channels[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
  
  /* Platform mux data */
@@ -5567,7 +5101,7 @@ index 742a0c2..c27548f 100644
  	{
  		.parent = 1,
  		.base_nr = MLXPLAT_CPLD_CH1,
-@@ -204,6 +294,14 @@ struct mlxplat_priv {
+@@ -204,6 +294,14 @@ static struct i2c_mux_reg_platform_data mlxplat_mux_data[] = {
  		.parent = 1,
  		.base_nr = MLXPLAT_CPLD_CH2,
  		.write_only = 1,
@@ -5582,7 +5116,7 @@ index 742a0c2..c27548f 100644
  		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
  		.reg_size = 1,
  		.idle_in_use = 1,
-@@ -254,6 +352,22 @@ struct mlxplat_priv {
+@@ -254,6 +352,22 @@ static struct i2c_board_info mlxplat_mlxcpld_fan[] = {
  	},
  };
  
@@ -5605,7 +5139,7 @@ index 742a0c2..c27548f 100644
  /* Platform hotplug default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_psu_items_data[] = {
  	{
-@@ -368,6 +482,45 @@ struct mlxplat_priv {
+@@ -368,6 +482,45 @@ static struct mlxreg_core_item mlxplat_mlxcpld_default_items[] = {
  	},
  };
  
@@ -5668,16 +5202,7 @@ index 742a0c2..c27548f 100644
  static struct mlxreg_core_data mlxplat_mlxcpld_msn21xx_pwr_items_data[] = {
  	{
  		.label = "pwr1",
-@@ -575,7 +738,7 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_msn274x_data = {
- 
- static
- struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_msn201x_data = {
--	.items = mlxplat_mlxcpld_msn21xx_items,
-+	.items = mlxplat_mlxcpld_msn201x_items,
- 	.counter = ARRAY_SIZE(mlxplat_mlxcpld_msn201x_items),
- 	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
- 	.mask = MLXPLAT_CPLD_AGGR_MASK_DEF,
-@@ -606,36 +769,48 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_msn201x_data = {
+@@ -606,36 +769,48 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_fan_items_data[] = {
  		.label = "fan1",
  		.reg = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
  		.mask = BIT(0),
@@ -5845,7 +5370,7 @@ index 742a0c2..c27548f 100644
  	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
-@@ -838,61 +1123,90 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_default_ng_data = {
+@@ -838,61 +1123,90 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_led_data[] = {
  		.label = "fan1:green",
  		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
  		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
@@ -5936,7 +5461,7 @@ index 742a0c2..c27548f 100644
  	},
  };
  
-@@ -901,61 +1215,135 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_default_ng_data = {
+@@ -901,64 +1215,138 @@ static struct mlxreg_core_platform_data mlxplat_default_ng_led_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_led_data),
  };
  
@@ -6024,8 +5549,9 @@ index 742a0c2..c27548f 100644
 +		.label = "fan3:green",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
 +		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
-+	},
-+	{
+ 	},
+ 	{
+-		.label = "reset_asic_thermal",
 +		.label = "fan3:red",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
 +		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
@@ -6107,10 +5633,13 @@ index 742a0c2..c27548f 100644
 +		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(6),
 +		.mode = 0444,
- 	},
- 	{
- 		.label = "reset_asic_thermal",
-@@ -1064,6 +1452,12 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_default_ng_data = {
++	},
++	{
++		.label = "reset_asic_thermal",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(7),
+ 		.mode = 0444,
+@@ -1064,6 +1452,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_msn21xx_regs_io_data[] = {
  		.mode = 0444,
  	},
  	{
@@ -6123,7 +5652,7 @@ index 742a0c2..c27548f 100644
  		.label = "psu1_on",
  		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
  		.mask = GENMASK(7, 0) & ~BIT(0),
-@@ -1088,6 +1482,12 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_default_ng_data = {
+@@ -1088,6 +1482,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_msn21xx_regs_io_data[] = {
  		.mode = 0200,
  	},
  	{
@@ -6136,7 +5665,7 @@ index 742a0c2..c27548f 100644
  		.label = "asic_health",
  		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
  		.mask = MLXPLAT_CPLD_ASIC_MASK,
-@@ -1101,6 +1501,221 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_default_ng_data = {
+@@ -1101,6 +1501,221 @@ static struct mlxreg_core_platform_data mlxplat_msn21xx_regs_io_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_msn21xx_regs_io_data),
  };
  
@@ -6358,7 +5887,7 @@ index 742a0c2..c27548f 100644
  /* Platform FAN default */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
  	{
-@@ -1111,61 +1726,89 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_default_ng_data = {
+@@ -1111,61 +1726,89 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
  		.label = "tacho1",
  		.reg = MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET,
  		.mask = GENMASK(7, 0),
@@ -6448,7 +5977,7 @@ index 742a0c2..c27548f 100644
  	},
  };
  
-@@ -1174,6 +1817,148 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_default_ng_data = {
+@@ -1174,6 +1817,148 @@ static struct mlxreg_core_platform_data mlxplat_default_fan_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_fan_data),
  };
  
@@ -6747,7 +6276,7 @@ index 742a0c2..c27548f 100644
  		return true;
  	}
  	return false;
-@@ -1305,6 +2153,25 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -1305,6 +2153,25 @@ static const struct reg_default mlxplat_mlxcpld_regmap_default[] = {
  	{ MLXPLAT_CPLD_LPC_REG_WP1_OFFSET, 0x00 },
  	{ MLXPLAT_CPLD_LPC_REG_WP2_OFFSET, 0x00 },
  	{ MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET, 0x00 },
@@ -6773,7 +6302,7 @@ index 742a0c2..c27548f 100644
  };
  
  struct mlxplat_mlxcpld_regmap_context {
-@@ -1345,21 +2212,70 @@ struct mlxplat_mlxcpld_regmap_context {
+@@ -1345,21 +2212,70 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config = {
  	.reg_write = mlxplat_mlxcpld_reg_write,
  };
  
@@ -6911,12 +6440,9 @@ index 742a0c2..c27548f 100644
  		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
  		mlxplat_mux_data[i].n_values =
  				ARRAY_SIZE(mlxplat_msn21xx_channels);
-@@ -1421,17 +2349,21 @@ static int __init mlxplat_dmi_msn201x_matched(const struct dmi_system_id *dmi)
- 	mlxplat_hotplug = &mlxplat_mlxcpld_msn201x_data;
- 	mlxplat_hotplug->deferred_nr =
+@@ -1423,15 +2351,19 @@ static int __init mlxplat_dmi_msn201x_matched(const struct dmi_system_id *dmi)
  		mlxplat_default_channels[i - 1][MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
--	mlxplat_led = &mlxplat_default_ng_led_data;
-+	mlxplat_led = &mlxplat_msn21xx_led_data;
+ 	mlxplat_led = &mlxplat_msn21xx_led_data;
  	mlxplat_regs_io = &mlxplat_msn21xx_regs_io_data;
 +	mlxplat_wd_data[0] = &mlxplat_mlxcpld_wd_set_type1[0];
  
@@ -6936,12 +6462,10 @@ index 742a0c2..c27548f 100644
  		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
  		mlxplat_mux_data[i].n_values =
  				ARRAY_SIZE(mlxplat_msn21xx_channels);
-@@ -1439,14 +2371,117 @@ static int __init mlxplat_dmi_qmb7xx_matched(const struct dmi_system_id *dmi)
- 	mlxplat_hotplug = &mlxplat_mlxcpld_default_ng_data;
+@@ -1440,13 +2372,116 @@ static int __init mlxplat_dmi_qmb7xx_matched(const struct dmi_system_id *dmi)
  	mlxplat_hotplug->deferred_nr =
  		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
--	mlxplat_led = &mlxplat_msn21xx_led_data;
-+	mlxplat_led = &mlxplat_default_ng_led_data;
+ 	mlxplat_led = &mlxplat_default_ng_led_data;
 +	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
  	mlxplat_fan = &mlxplat_default_fan_data;
 +	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
@@ -7056,7 +6580,7 @@ index 742a0c2..c27548f 100644
  		.callback = mlxplat_dmi_msn274x_matched,
  		.matches = {
  			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
-@@ -1499,51 +2534,28 @@ static int __init mlxplat_dmi_qmb7xx_matched(const struct dmi_system_id *dmi)
+@@ -1499,51 +2534,28 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  		.callback = mlxplat_dmi_qmb7xx_matched,
  		.matches = {
  			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
@@ -7305,7 +6829,7 @@ index 742a0c2..c27548f 100644
  
  	platform_device_unregister(priv->pdev_i2c);
 diff --git a/drivers/watchdog/Kconfig b/drivers/watchdog/Kconfig
-index b165c46..5763dfc 100644
+index 709d4de..da31a4b 100644
 --- a/drivers/watchdog/Kconfig
 +++ b/drivers/watchdog/Kconfig
 @@ -241,6 +241,22 @@ config RAVE_SP_WATCHDOG
@@ -7732,5 +7256,5 @@ index dc69391..08bb155 100644
  /* The reset() operation must clear the flags for the components which
   * were actually reset.  On successful return, the flags indicate the
 -- 
-1.9.1
+2.11.0
 

--- a/patch/0005-hwmon-pmbus-core-Add-support-for-vid-mode-detection-.patch
+++ b/patch/0005-hwmon-pmbus-core-Add-support-for-vid-mode-detection-.patch
@@ -1,8 +1,8 @@
-From 5766c21f1bb28b43048f188195e8bae90163049c Mon Sep 17 00:00:00 2001
+From 7b4746d925e3173141005f414a239224bd765488 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@mellanox.com>
-Date: Thu, 12 Mar 2020 17:17:25 +0200
-Subject: [PATCH] hwmon: (pmbus/core) Add support for vid mode detection per
- page bases
+Date: Mon, 29 Jun 2020 19:05:59 +0300
+Subject: [backport 04/12] hwmon: (pmbus/core) Add support for vid mode
+ detection per page bases
 
 Add support for VID protocol detection per page bases, instead of
 detecting it based on PMBU_VOUT readout from page 0.
@@ -22,56 +22,23 @@ VR12.0 mode, 5-mV DAC - 0x01;
 VR12.5 mode, 10-mV DAC - 0x02;
 IMVP9 mode, 5-mV DAC - 0x03;
 AMD mode 6.25mV - 0x10.
-
-Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
-Signed-off-by: Stephen Sun <stephens@mellanox.com>
 ---
- debian/build/build_amd64_none_amd64/.config |   5 +-
- drivers/hwmon/pmbus/Kconfig                 |   9 ++
- drivers/hwmon/pmbus/Makefile                |   1 +
- drivers/hwmon/pmbus/max20751.c              |   2 +-
- drivers/hwmon/pmbus/pmbus.c                 |   5 +-
- drivers/hwmon/pmbus/pmbus.h                 |   4 +-
- drivers/hwmon/pmbus/pmbus_core.c            |  10 +-
- drivers/hwmon/pmbus/tps53679.c              |  44 ++---
- drivers/hwmon/pmbus/xdpe12284.c             | 171 ++++++++++++++++++++
- 9 files changed, 222 insertions(+), 29 deletions(-)
+ drivers/hwmon/pmbus/Kconfig      |   9 +++
+ drivers/hwmon/pmbus/Makefile     |   1 +
+ drivers/hwmon/pmbus/max20751.c   |   2 +-
+ drivers/hwmon/pmbus/pmbus.c      |   5 +-
+ drivers/hwmon/pmbus/pmbus.h      |   4 +-
+ drivers/hwmon/pmbus/pmbus_core.c |  10 ++-
+ drivers/hwmon/pmbus/tps53679.c   |  44 +++++-----
+ drivers/hwmon/pmbus/xdpe12284.c  | 171 +++++++++++++++++++++++++++++++++++++++
+ 8 files changed, 219 insertions(+), 27 deletions(-)
  create mode 100644 drivers/hwmon/pmbus/xdpe12284.c
 
-diff --git a/debian/build/build_amd64_none_amd64/.config b/debian/build/build_amd64_none_amd64/.config
-index e787c2796..5d7a68019 100644
---- a/debian/build/build_amd64_none_amd64/.config
-+++ b/debian/build/build_amd64_none_amd64/.config
-@@ -4205,8 +4205,6 @@ CONFIG_SENSORS_ATXP1=m
- CONFIG_SENSORS_DS620=m
- CONFIG_SENSORS_DS1621=m
- CONFIG_SENSORS_DELL_SMM=m
--CONFIG_SENSORS_DNI_DPS460=m
--CONFIG_SENSORS_DPS1900=m
- CONFIG_SENSORS_I5K_AMB=m
- CONFIG_SENSORS_F71805F=m
- CONFIG_SENSORS_F71882FG=m
-@@ -4290,12 +4288,15 @@ CONFIG_SENSORS_LM25066=m
- # CONFIG_SENSORS_MAX20751 is not set
- # CONFIG_SENSORS_MAX31785 is not set
- # CONFIG_SENSORS_MAX34440 is not set
-+CONFIG_SENSORS_DNI_DPS460=m
- # CONFIG_SENSORS_MAX8688 is not set
- # CONFIG_SENSORS_TPS40422 is not set
- CONFIG_SENSORS_TPS53679=m
- CONFIG_SENSORS_UCD9000=m
- CONFIG_SENSORS_UCD9200=m
-+CONFIG_SENSORS_XDPE122=m
- # CONFIG_SENSORS_ZL6100 is not set
-+CONFIG_SENSORS_DPS1900=m
- # CONFIG_SENSORS_SHT15 is not set
- CONFIG_SENSORS_SHT21=m
- # CONFIG_SENSORS_SHT3x is not set
 diff --git a/drivers/hwmon/pmbus/Kconfig b/drivers/hwmon/pmbus/Kconfig
-index 505ca2be0..eda871222 100644
+index a82018a..14c0572 100644
 --- a/drivers/hwmon/pmbus/Kconfig
 +++ b/drivers/hwmon/pmbus/Kconfig
-@@ -196,6 +196,15 @@ config SENSORS_UCD9200
+@@ -186,6 +186,15 @@ config SENSORS_UCD9200
  	  This driver can also be built as a module. If so, the module will
  	  be called ucd9200.
  
@@ -88,18 +55,17 @@ index 505ca2be0..eda871222 100644
  	tristate "Intersil ZL6100 and compatibles"
  	default n
 diff --git a/drivers/hwmon/pmbus/Makefile b/drivers/hwmon/pmbus/Makefile
-index c76820a4d..edc7c315c 100644
+index ea0e395..8c8edb5 100644
 --- a/drivers/hwmon/pmbus/Makefile
 +++ b/drivers/hwmon/pmbus/Makefile
-@@ -21,5 +21,6 @@ obj-$(CONFIG_SENSORS_TPS40422)	+= tps40422.o
+@@ -20,4 +20,5 @@ obj-$(CONFIG_SENSORS_TPS40422)	+= tps40422.o
  obj-$(CONFIG_SENSORS_TPS53679)	+= tps53679.o
  obj-$(CONFIG_SENSORS_UCD9000)	+= ucd9000.o
  obj-$(CONFIG_SENSORS_UCD9200)	+= ucd9200.o
 +obj-$(CONFIG_SENSORS_XDPE122)	+= xdpe12284.o
  obj-$(CONFIG_SENSORS_ZL6100)	+= zl6100.o
- obj-$(CONFIG_SENSORS_DPS1900)	+= dps1900.o
 diff --git a/drivers/hwmon/pmbus/max20751.c b/drivers/hwmon/pmbus/max20751.c
-index ab74aeae8..394c662c8 100644
+index ab74aea..394c662 100644
 --- a/drivers/hwmon/pmbus/max20751.c
 +++ b/drivers/hwmon/pmbus/max20751.c
 @@ -25,7 +25,7 @@ static struct pmbus_driver_info max20751_info = {
@@ -112,7 +78,7 @@ index ab74aeae8..394c662c8 100644
  	.format[PSC_CURRENT_OUT] = linear,
  	.format[PSC_POWER] = linear,
 diff --git a/drivers/hwmon/pmbus/pmbus.c b/drivers/hwmon/pmbus/pmbus.c
-index 7688dab32..4db0400b7 100644
+index 7688dab..4db0400 100644
 --- a/drivers/hwmon/pmbus/pmbus.c
 +++ b/drivers/hwmon/pmbus/pmbus.c
 @@ -123,7 +123,7 @@ static int pmbus_identify(struct i2c_client *client,
@@ -135,7 +101,7 @@ index 7688dab32..4db0400b7 100644
  			case 2:
  				info->format[PSC_VOLTAGE_OUT] = direct;
 diff --git a/drivers/hwmon/pmbus/pmbus.h b/drivers/hwmon/pmbus/pmbus.h
-index 1d24397d3..5481ff9f8 100644
+index 1d24397..5481ff9 100644
 --- a/drivers/hwmon/pmbus/pmbus.h
 +++ b/drivers/hwmon/pmbus/pmbus.h
 @@ -375,12 +375,12 @@ enum pmbus_sensor_classes {
@@ -154,7 +120,7 @@ index 1d24397d3..5481ff9f8 100644
  	 * Support one set of coefficients for each sensor type
  	 * Used for chips providing data in direct mode.
 diff --git a/drivers/hwmon/pmbus/pmbus_core.c b/drivers/hwmon/pmbus/pmbus_core.c
-index cd24b375d..1d7f950e6 100644
+index cd24b37..1d7f950 100644
 --- a/drivers/hwmon/pmbus/pmbus_core.c
 +++ b/drivers/hwmon/pmbus/pmbus_core.c
 @@ -709,7 +709,7 @@ static long pmbus_reg2data_vid(struct pmbus_data *data,
@@ -182,7 +148,7 @@ index cd24b375d..1d7f950e6 100644
  	return rv;
  }
 diff --git a/drivers/hwmon/pmbus/tps53679.c b/drivers/hwmon/pmbus/tps53679.c
-index 45eacc504..28d3de029 100644
+index 2bc352c..0a30101 100644
 --- a/drivers/hwmon/pmbus/tps53679.c
 +++ b/drivers/hwmon/pmbus/tps53679.c
 @@ -33,27 +33,29 @@ static int tps53679_identify(struct i2c_client *client,
@@ -238,7 +204,7 @@ index 45eacc504..28d3de029 100644
  	return 0;
 diff --git a/drivers/hwmon/pmbus/xdpe12284.c b/drivers/hwmon/pmbus/xdpe12284.c
 new file mode 100644
-index 000000000..660556b89
+index 0000000..660556b
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/xdpe12284.c
 @@ -0,0 +1,171 @@
@@ -414,5 +380,5 @@ index 000000000..660556b89
 +MODULE_DESCRIPTION("PMBus driver for Infineon XDPE122 family");
 +MODULE_LICENSE("GPL");
 -- 
-2.20.1
+2.11.0
 

--- a/patch/series
+++ b/patch/series
@@ -68,7 +68,7 @@ net-fix-skb-csum-update-in-inet_proto_csum_replace16.patch
 # Tbridge-per-port-multicast-broadcast-flood-flags.patch
 #
 # Mellanox patches for 4.19
-0001-v4.19-6-Mellanox-platform-Backport-patches-for-new-M.patch
+0001-Mellanox-platform-Backport-patches-for-new-Mellanox-.patch
 0002-config-mellanox-configuration.patch
 0003-mlxsw-minimal-Fix-validation-for-FW-minor-version.patch
 0004-mlxsw-core-Add-the-hottest-thermal-zone-detection.patch


### PR DESCRIPTION
Below two patches are updated for kernel upgrade to 4.19.118:

0001-Mellanox-platform-Backport-patches-for-new-Mellanox-.patch
0005-hwmon-pmbus-core-Add-support-for-vid-mode-detection-.patch